### PR TITLE
Systemd service file for IceS

### DIFF
--- a/systemd/ices2.service
+++ b/systemd/ices2.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Vinyl Streaming Service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/ices2 /etc/ices2/ices-alsa.xml
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Added a systemd service file for IceS so the streaming client starts
automatically when the hardware is rebooted.